### PR TITLE
JSV-922 add scan depth, code scan, and vulnerability fetch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSMon CLI
 
-The official command-line tool for [JSMon](https://jsmon.sh). Scan URLs and domains, upload files, and explore reconnaissance data—all from your terminal.
+The official command-line tool for [JSMon](https://jsmon.sh). Scan URLs, domains, and source code, upload files, and explore reconnaissance and vulnerability data from your terminal.
 
 ![JSMon CLI - Help](docs/screenshots/help.png)
 
@@ -91,6 +91,7 @@ The workspace ID is **not** read from the credentials file; it must be provided 
 
 - **`-H "Header-Name: value"`** — Add custom HTTP headers for scan requests (can be used multiple times).
 - **`-silent`** — Hide the JSMon logo when running commands.
+- **`-depth 1..4` / `-scan-depth 1..4`** — Control domain scan depth.
 
 ![Configuration - Credentials and workspace](docs/screenshots/config.png)
 
@@ -104,12 +105,14 @@ Usage: jsmon-cli [OPTIONS]
 Input:
   -u <input>                                  Input URL to scan
   -d <input>                                  Input domain to scan
+  -cs <input> | -code-scan <input>            Input source code file to scan
   -f <input>                                  Input file of URLs to scan (one URL per line)
   -cw <input> | --create-workspace <input>    Create a new workspace
 
 Configuration:
   -key <input>                                API key (or add the API key to ~/.jsmon/credentials)
   -wksp <wksp id>                             Workspace ID to scan the target
+  -depth <1..4> | -scan-depth <1..4>          Optional scan depth for domain scans
   -H <input>                                  Custom HTTP headers to send along with request to scan
   -resume                                     Resume scan using resume.config
                                               (resumes from last scan failed due to force stop or API limits)
@@ -125,6 +128,8 @@ Scans:
 
 Data:
   -workspaces                                 Fetch all workspaces
+  -issues "page=<n> limit=<n> ..."            Fetch dashboard vulnerabilities for a workspace (default: page=1, limit=100)
+                                              Supported options: severity, dateFrom, dateTo
   -secrets "page=<number> limit=<number>"      Fetch all secrets for a workspace (default: page=1, limit=100)
   -recon "field=<name> page=<number> limit=<number>"
                                               Fetch the reconnaissance data (default: page=1, limit=100)
@@ -167,6 +172,13 @@ jsmon -u "https://example.com/script.js" -wksp YOUR_WORKSPACE_ID
 
 ```bash
 jsmon -d "example.com" -wksp YOUR_WORKSPACE_ID
+jsmon -d "example.com" -depth 3 -wksp YOUR_WORKSPACE_ID
+```
+
+### Upload a source code file
+
+```bash
+jsmon -cs app.js -wksp YOUR_WORKSPACE_ID
 ```
 
 ### Upload multiple URLs from a file
@@ -212,6 +224,15 @@ Default is `page=1` and `limit=100` if omitted. (Max limit: 5000 per page)
 ```bash
 jsmon -secrets "page=1 limit=100" -wksp YOUR_WORKSPACE_ID
 ```
+
+### Dashboard vulnerabilities (`-issues`)
+
+```bash
+jsmon -issues "page=1 limit=20" -wksp YOUR_WORKSPACE_ID
+jsmon -issues "page=1 limit=20 severity=critical,high dateFrom=2026-04-01 dateTo=2026-04-14" -wksp YOUR_WORKSPACE_ID
+```
+
+The `-issues` command mirrors the mounted dashboard vulnerability table and returns `data`, `severityCount`, and `pagination`.
 
 ### Count summary
 
@@ -286,6 +307,8 @@ jsmon -cw "My Project" -key YOUR_API_KEY
 # Scan targets
 jsmon -u "https://example.com/script.js" -wksp YOUR_WORKSPACE_ID
 jsmon -d "example.com" -wksp YOUR_WORKSPACE_ID
+jsmon -d "example.com" -depth 2 -wksp YOUR_WORKSPACE_ID
+jsmon -cs app.js -wksp YOUR_WORKSPACE_ID
 jsmon -f urls.txt -wksp YOUR_WORKSPACE_ID
 
 # Use credentials file (no -key needed)
@@ -294,6 +317,7 @@ jsmon -u "https://example.com/script.js" -wksp YOUR_WORKSPACE_ID
 # Reconnaissance
 jsmon -recon "field=emails page=1" -wksp YOUR_WORKSPACE_ID
 jsmon -recon "field=allAwsAssets page=1" -wksp YOUR_WORKSPACE_ID
+jsmon -issues "page=1 limit=20 severity=critical,high" -wksp YOUR_WORKSPACE_ID
 
 # Filter and reverse search
 jsmon -filters "urls=api page=1" -wksp YOUR_WORKSPACE_ID

--- a/api/client.go
+++ b/api/client.go
@@ -528,7 +528,7 @@ type TotalCountAnalysis struct {
 	TotalValidNodeModules               int `json:"totalValidNodeModules"`
 	TotalQueryParamsUrls                int `json:"totalQueryParamsUrls"`
 	TotalS3DomainsInvalid               int `json:"totalS3DomainsInvalid"`
-	TotalExtractedDomainsStatus         int `json:"totalExtractedDomainsStatus"`
+	TotalExpiredDomains                 int `json:"totalExpiredDomains"`
 	TotalSocialMediaUrls                int `json:"totalSocialMediaUrls"`
 	TotalLocalhostUrls                  int `json:"totalLocalhostUrls"`
 	TotalFilteredPortUrls               int `json:"totalFilteredPortUrls"`
@@ -1195,8 +1195,7 @@ func mapFieldToOptions(field string) string {
 		"npmconfusion":     "invalidnodemodules",
 		"guids":            "guids",
 		"localhost":        "localhost",
-		"activedomains":    "domainsstatus",
-		"inactivedomains":  "domainsstatus",
+		"expireddomains":   "expireddomains",
 		"allawsassets":     "awsassets",
 		"queryparam":       "queryparams",
 		"socialurls":       "socialmediaurls",
@@ -1214,13 +1213,6 @@ func mapFieldToOptions(field string) string {
 
 // getStatusForField returns the status parameter value for fields that require it
 func getStatusForField(field string) string {
-	fieldLower := strings.ToLower(field)
-	if fieldLower == "activedomains" {
-		return "active"
-	}
-	if fieldLower == "inactivedomains" {
-		return "inactive"
-	}
 	return ""
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -154,12 +154,17 @@ func (c *Client) CreateWorkspace(workspaceName string) (string, error) {
 		return "", fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	workspaceID, ok := result["workspaceId"].(string)
-	if !ok {
-		return "", fmt.Errorf("workspaceId not found in response")
+	if workspaceID, ok := result["workspaceId"].(string); ok && strings.TrimSpace(workspaceID) != "" {
+		return workspaceID, nil
 	}
 
-	return workspaceID, nil
+	if workspace, ok := result["workspace"].(map[string]interface{}); ok {
+		if workspaceID, ok := workspace["wkspId"].(string); ok && strings.TrimSpace(workspaceID) != "" {
+			return workspaceID, nil
+		}
+	}
+
+	return "", fmt.Errorf("workspace id not found in response")
 }
 
 // UploadURL uploads a URL for scanning

--- a/api/client.go
+++ b/api/client.go
@@ -72,6 +72,15 @@ type Client struct {
 	Headers    map[string]string
 }
 
+// IssuesQueryOptions represents supported /vulnerability query parameters.
+type IssuesQueryOptions struct {
+	Page     int
+	Limit    int
+	Severity []string
+	DateFrom string
+	DateTo   string
+}
+
 // NewClient creates a new API client
 func NewClient(apiKey string, headers map[string]string) *Client {
 	// Ensure headers map is never nil
@@ -83,6 +92,19 @@ func NewClient(apiKey string, headers map[string]string) *Client {
 		HTTPClient: &http.Client{},
 		Headers:    headers,
 	}
+}
+
+func extractAPIMessage(body []byte) string {
+	message := strings.TrimSpace(string(body))
+	var errorResp map[string]interface{}
+	if err := json.Unmarshal(body, &errorResp); err == nil {
+		for _, key := range []string{"message", "error", "errorMessage", "msg"} {
+			if msg, ok := errorResp[key].(string); ok && strings.TrimSpace(msg) != "" {
+				return strings.TrimSpace(msg)
+			}
+		}
+	}
+	return message
 }
 
 // CreateWorkspace creates a new workspace
@@ -199,12 +221,15 @@ func (c *Client) UploadURL(jsURL, workspaceID string) error {
 	return nil
 }
 
-// ScanDomain scans a domain
-func (c *Client) ScanDomain(domain, workspaceID string) error {
+// ScanDomain scans a domain with an optional scan depth.
+func (c *Client) ScanDomain(domain, workspaceID string, scanDepth int) error {
 	endpoint := APIBaseURL + "/automateScanDomain?wkspId=" + url.QueryEscape(workspaceID) + "&source=" + url.QueryEscape("cliScan")
 
 	payload := map[string]interface{}{
 		"domain": domain,
+	}
+	if scanDepth > 0 {
+		payload["scanDepth"] = scanDepth
 	}
 
 	// Include custom headers in the payload if any are provided
@@ -356,6 +381,63 @@ func (c *Client) ScanDomain(domain, workspaceID string) error {
 		return &APIError{
 			URL:     domain,
 			Message: errorMessage,
+			Status:  resp.StatusCode,
+		}
+	}
+
+	return nil
+}
+
+// UploadCodeFile uploads a source code file for code scanning.
+func (c *Client) UploadCodeFile(filePath, workspaceID string) error {
+	endpoint := APIBaseURL + "/directFileScan?wkspId=" + url.QueryEscape(workspaceID)
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		return fmt.Errorf("failed to create form file: %w", err)
+	}
+	if _, err = io.Copy(part, file); err != nil {
+		return fmt.Errorf("failed to copy file data: %w", err)
+	}
+	if err = writer.Close(); err != nil {
+		return fmt.Errorf("failed to close writer: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", endpoint, &requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("X-Jsmon-Key", strings.TrimSpace(c.APIKey))
+	for key, value := range c.Headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &APIError{
+			URL:     filePath,
+			Message: extractAPIMessage(body),
 			Status:  resp.StatusCode,
 		}
 	}
@@ -920,6 +1002,84 @@ type Secret struct {
 	Occurrences int    `json:"occurrences"`
 	ModuleName  string `json:"moduleName"`
 	Source      string `json:"source"`
+}
+
+// IssueRecord represents a single vulnerability row from the dashboard /vulnerability API.
+type IssueRecord struct {
+	ID        string `json:"id,omitempty"`
+	VulnType  string `json:"vulnType,omitempty"`
+	Severity  string `json:"severity,omitempty"`
+	VulnValue string `json:"vulnValue,omitempty"`
+	JSURL     string `json:"jsUrl,omitempty"`
+	ScannedOn string `json:"scannedOn,omitempty"`
+}
+
+// GetIssuesResponse represents the mounted dashboard /vulnerability API response.
+type GetIssuesResponse struct {
+	Data          []IssueRecord          `json:"data"`
+	SeverityCount map[string]interface{} `json:"severityCount,omitempty"`
+	Pagination    map[string]interface{} `json:"pagination,omitempty"`
+}
+
+// GetIssues retrieves the mounted dashboard table data from the /vulnerability API.
+func (c *Client) GetIssues(workspaceID string, options IssuesQueryOptions) (*GetIssuesResponse, error) {
+	params := url.Values{}
+	params.Set("wkspId", workspaceID)
+	if options.Page > 0 {
+		params.Set("page", fmt.Sprintf("%d", options.Page))
+	}
+	if options.Limit > 0 {
+		params.Set("limit", fmt.Sprintf("%d", options.Limit))
+	}
+	if len(options.Severity) > 0 {
+		severity := strings.Join(options.Severity, ",")
+		if severity != "" {
+			params.Set("severity", severity)
+		}
+	}
+	if options.DateFrom != "" {
+		params.Set("dateFrom", options.DateFrom)
+	}
+	if options.DateTo != "" {
+		params.Set("dateTo", options.DateTo)
+	}
+
+	endpoint := APIBaseURL + "/vulnerability?" + params.Encode()
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("X-Jsmon-Key", strings.TrimSpace(c.APIKey))
+	for key, value := range c.Headers {
+		req.Header.Set(key, value)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &APIError{
+			URL:     endpoint,
+			Message: extractAPIMessage(body),
+			Status:  resp.StatusCode,
+		}
+	}
+
+	var response GetIssuesResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
 }
 
 // GetSecretsResponse represents the response from keysAndSecrets API

--- a/handlers/code.go
+++ b/handlers/code.go
@@ -1,0 +1,40 @@
+package handlers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jsmonhq/jsmon-cli/api"
+)
+
+// HandleCodeScan uploads a source code file for code scanning.
+func HandleCodeScan(filePath, workspaceID, apiKey string, headers map[string]string) {
+	fmt.Printf("Code scan started for - %s\n", filePath)
+
+	client := api.NewClient(apiKey, headers)
+	err := client.UploadCodeFile(filePath, workspaceID)
+	if err != nil {
+		if apiErr, ok := err.(*api.APIError); ok {
+			if apiErr.IsAuthError() {
+				fmt.Fprintf(os.Stderr, "Error: API key is invalid. Use -key flag, add to ~/.jsmon/credentials, or set JSMON_API_KEY environment variable\n")
+				os.Exit(1)
+			}
+			if apiErr.IsInsufficientLimitsError() {
+				fmt.Fprintf(os.Stderr, "%sInsufficient scan limits%s\n", ColorRed, ColorReset)
+				fmt.Fprintf(os.Stderr, "%sPlease add scan limits and try again%s\n", ColorRed, ColorReset)
+				os.Exit(1)
+			}
+			if apiErr.IsRateLimitError() {
+				fmt.Fprintf(os.Stderr, "%sRate limit reached%s\n", ColorRed, ColorReset)
+				fmt.Fprintf(os.Stderr, "%sPlease try again later%s\n", ColorRed, ColorReset)
+				os.Exit(1)
+			}
+			fmt.Fprintf(os.Stderr, "%sError uploading code file: %s - %s%s\n", ColorRed, filePath, apiErr.Message, ColorReset)
+		} else {
+			fmt.Fprintf(os.Stderr, "%sError uploading code file: %s - %v%s\n", ColorRed, filePath, err, ColorReset)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("%sCode scan completed for - %s%s\n", ColorGreen, filePath, ColorReset)
+}

--- a/handlers/count.go
+++ b/handlers/count.go
@@ -121,7 +121,7 @@ func HandleCount(workspaceID, apiKey string, headers map[string]string, runID st
 	// 🔗 URLs & Links (sorted by count)
 	fmt.Printf("\n%s🔗 URLs & Links%s\n", ColorGreen, ColorReset)
 	displaySortedCounts([]countItem{
-		{"Total Extracted Domains Status", countAnalysis.TotalExtractedDomainsStatus},
+		{"Total Expired Domains", countAnalysis.TotalExpiredDomains},
 		{"Total File Extension URLs", countAnalysis.TotalFileExtensionUrls},
 		{"Total Filtered Port URLs", countAnalysis.TotalFilteredPortUrls},
 		{"Total Localhost URLs", countAnalysis.TotalLocalhostUrls},

--- a/handlers/domain.go
+++ b/handlers/domain.go
@@ -8,15 +8,15 @@ import (
 	"github.com/jsmonhq/jsmon-cli/api"
 )
 
-// HandleDomainScan scans a domain. The exact value passed via -d is sent to the API (no trimming of scheme or port).
-func HandleDomainScan(domain, workspaceID, apiKey string, resumeFile string, headers map[string]string) {
+// HandleDomainScan scans a domain. The exact value passed via -d is sent to the API.
+func HandleDomainScan(domain, workspaceID, apiKey string, resumeFile string, headers map[string]string, scanDepth int) {
 	domain = strings.TrimSpace(domain)
 
 	// Domain scanning does not support resume functionality
 	// Resume is only available for file scanning
 
 	client := api.NewClient(apiKey, headers)
-	err := client.ScanDomain(domain, workspaceID)
+	err := client.ScanDomain(domain, workspaceID, scanDepth)
 	if err != nil {
 		// Check if it's an APIError
 		if apiErr, ok := err.(*api.APIError); ok {

--- a/handlers/issues.go
+++ b/handlers/issues.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/jsmonhq/jsmon-cli/api"
+)
+
+// HandleIssues fetches workspace issues and prints them in JSON format.
+func HandleIssues(workspaceID, apiKey string, headers map[string]string, options api.IssuesQueryOptions) {
+	client := api.NewClient(apiKey, headers)
+
+	response, err := client.GetIssues(workspaceID, options)
+	if err != nil {
+		if apiErr, ok := err.(*api.APIError); ok && apiErr.IsAuthError() {
+			fmt.Fprintf(os.Stderr, "Error: API key is invalid or not configured. Use -key flag, add to ~/.jsmon/credentials, or set JSMON_API_KEY environment variable\n")
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "%sError fetching issues: %v%s\n", ColorRed, err, ColorReset)
+		os.Exit(1)
+	}
+
+	jsonOutput, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%sError marshaling JSON: %v%s\n", ColorRed, err, ColorReset)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(jsonOutput))
+}

--- a/handlers/reconnaissance.go
+++ b/handlers/reconnaissance.go
@@ -15,13 +15,6 @@ type ParamValue struct {
 	Parameters []map[string]interface{} `json:"parameters"`
 }
 
-// DomainStatusValue represents a domain status value with domainName, status, and expiryDate
-type DomainStatusValue struct {
-	DomainName string `json:"domainName"`
-	Status     string `json:"status"`
-	ExpiryDate string `json:"expiryDate"`
-}
-
 // HandleJSIntelligence displays reconnaissance data for a workspace in raw JSON format
 func HandleJSIntelligence(workspaceID, apiKey string, headers map[string]string, field string, page int, limit int) {
 	client := api.NewClient(apiKey, headers)
@@ -47,7 +40,6 @@ func HandleJSIntelligence(workspaceID, apiKey string, headers map[string]string,
 
 	// Check if this is a field with object values (not strings)
 	isParamField := strings.ToLower(field) == "param"
-	isDomainStatusField := strings.ToLower(field) == "activedomains" || strings.ToLower(field) == "inactivedomains"
 	isAwsAssetsField := strings.ToLower(field) == "awsassets" || strings.ToLower(field) == "allawsassets"
 
 	var output interface{}
@@ -82,40 +74,6 @@ func HandleJSIntelligence(workspaceID, apiKey string, headers map[string]string,
 			}
 		}
 		output = paramValues
-	} else if isDomainStatusField {
-		// For domain status fields, extract the full value objects
-		var domainValues []DomainStatusValue
-		if data, ok := response["data"].([]interface{}); ok {
-			for _, item := range data {
-				if itemMap, ok := item.(map[string]interface{}); ok {
-					if value, exists := itemMap["value"]; exists && value != nil {
-						if valueMap, ok := value.(map[string]interface{}); ok {
-							domainValue := DomainStatusValue{}
-							if domainName, exists := valueMap["domainName"]; exists {
-								if domainNameStr, ok := domainName.(string); ok {
-									domainValue.DomainName = domainNameStr
-								}
-							}
-							if status, exists := valueMap["status"]; exists {
-								if statusStr, ok := status.(string); ok {
-									domainValue.Status = statusStr
-								}
-							}
-							if expiryDate, exists := valueMap["expiryDate"]; exists {
-								// expiryDate can be a string or null, handle both
-								if expiryDateStr, ok := expiryDate.(string); ok {
-									domainValue.ExpiryDate = expiryDateStr
-								} else if expiryDate == nil {
-									domainValue.ExpiryDate = "NULL"
-								}
-							}
-							domainValues = append(domainValues, domainValue)
-						}
-					}
-				}
-			}
-		}
-		output = domainValues
 	} else if isAwsAssetsField {
 		// For awsassets field, extract the full value objects (AWS assets are objects)
 		var awsAssets []map[string]interface{}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jsmonhq/jsmon-cli/api"
 	"github.com/jsmonhq/jsmon-cli/config"
 	"github.com/jsmonhq/jsmon-cli/handlers"
 )
@@ -49,7 +50,7 @@ func main() {
 	// This extracts -H flags and removes them from os.Args so flag.Parse() doesn't see them
 	headers, filteredArgs := parseHeadersAndFilterArgs()
 
-	// Extract --urls, --domains, --files, -secrets, -recon, -rsearch, and -filters flags and their values before flag.Parse() to prevent them from consuming -wksp
+	// Extract custom flags and their values before flag.Parse() to prevent them from consuming -wksp
 	urlsFlagProvided := false
 	urlsValue := ""
 	domainsFlagProvided := false
@@ -64,8 +65,10 @@ func main() {
 	rsearchValue := ""
 	filtersFlagProvided := false
 	filtersValue := ""
+	issuesFlagProvided := false
+	issuesValue := ""
 
-	// First, check originalArgs to find --urls, --domains, --files, -secrets, -recon, -rsearch, and -filters and their values
+	// First, check originalArgs to find custom flags and their values
 	for i, arg := range originalArgs {
 		if arg == "--urls" {
 			urlsFlagProvided = true
@@ -120,6 +123,12 @@ func main() {
 			// Check if next argument is a value (contains "fieldname=" and optionally "page=")
 			if i+1 < len(originalArgs) {
 				filtersValue = originalArgs[i+1]
+			}
+		}
+		if arg == "-issues" {
+			issuesFlagProvided = true
+			if i+1 < len(originalArgs) && looksLikeKeyValueArg(originalArgs[i+1]) {
+				issuesValue = originalArgs[i+1]
 			}
 		}
 	}
@@ -193,6 +202,13 @@ func main() {
 			}
 			continue
 		}
+		if arg == "-issues" {
+			// Skip -issues flag and its optional key=value argument string
+			if i+1 < len(filteredArgs) && looksLikeKeyValueArg(filteredArgs[i+1]) {
+				i++
+			}
+			continue
+		}
 		// Skip page=/limit= value if it's not immediately after --urls, --domains, --files, or -secrets (shouldn't happen, but just in case)
 		if (strings.Contains(arg, "page=") || strings.Contains(arg, "limit=")) && (urlsFlagProvided || domainsFlagProvided || filesFlagProvided || secretsFlagProvided) {
 			continue
@@ -216,16 +232,22 @@ func main() {
 	// Define flags
 	urlFlag := flag.String("u", "", "Input URL to scan")
 	domainFlag := flag.String("d", "", "Input domain to scan")
+	codeScanFlag := flag.String("cs", "", "Input source code file to scan")
+	codeScanFlagAlt := flag.String("code-scan", "", "Input source code file to scan")
 	fileFlag := flag.String("f", "", "Input file of URLs to scan (one URL per line)")
 	createWorkspaceFlag := flag.String("cw", "", "Create a new workspace (use --create-workspace as alternative)")
 	createWorkspaceFlagAlt := flag.String("create-workspace", "", "Create a new workspace")
 	apiKeyFlag := flag.String("key", "", "JSMon API key (or set in ~/.jsmon/credentials)")
 	workspaceIDFlag := flag.String("wksp", "", "Workspace ID (or set in ~/.jsmon/credentials)")
+	depthFlag := flag.Int("depth", 0, "Optional scan depth for domain scans (1-4)")
+	depthFlagAlt := flag.Int("scan-depth", 0, "Optional scan depth for domain scans (1-4)")
 	resumeFlag := flag.String("resume", "", "Resume from a previous scan using resume.cfg file")
 	countFlag := flag.Bool("count", false, "Show count analysis for the workspace")
 	runIDFlag := flag.String("runId", "", "Run ID for count analysis (optional)")
 	workspacesFlag := flag.Bool("workspaces", false, "List all workspaces")
 	_ = flag.Bool("silent", false, "Suppress logo output") // Flag is checked in showUsage()
+	_ = flag.Bool("duc", false, "Disable automatic update check on startup")
+	_ = flag.Bool("disable-update-check", false, "Disable automatic update check on startup")
 	helpFlag := flag.Bool("h", false, "Show help message")
 	helpFlagAlt := flag.Bool("help", false, "Show help message")
 
@@ -287,6 +309,18 @@ func main() {
 	workspaceName := *createWorkspaceFlag
 	if workspaceName == "" {
 		workspaceName = *createWorkspaceFlagAlt
+	}
+	codeScanPath := *codeScanFlag
+	if codeScanPath == "" {
+		codeScanPath = *codeScanFlagAlt
+	}
+	scanDepth := *depthFlag
+	if scanDepth == 0 {
+		scanDepth = *depthFlagAlt
+	}
+	if scanDepth != 0 && (scanDepth < 1 || scanDepth > 4) {
+		fmt.Fprintf(os.Stderr, "Error: Scan depth must be between 1 and 4. Use -depth <1..4> or -scan-depth <1..4>\n")
+		os.Exit(1)
 	}
 
 	// Route to appropriate handler
@@ -609,6 +643,22 @@ func main() {
 		}
 
 		handlers.HandleFilter(workspaceID, apiKey, headers, fieldname, keyword, page, limit)
+	} else if issuesFlagProvided {
+		if apiKey == "" {
+			fmt.Fprintf(os.Stderr, "Error: API key is required. Use -key flag, add to ~/.jsmon/credentials, or set JSMON_API_KEY environment variable\n")
+			os.Exit(1)
+		}
+		if workspaceID == "" {
+			fmt.Fprintf(os.Stderr, "Error: Workspace ID is required. Use -wksp flag or set JSMON_WORKSPACE_ID environment variable\n")
+			os.Exit(1)
+		}
+		issueOptions, err := parseIssuesOptions(issuesValue)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
+			showUsage()
+			os.Exit(1)
+		}
+		handlers.HandleIssues(workspaceID, apiKey, headers, issueOptions)
 	} else if *workspacesFlag {
 		// List all workspaces
 		if apiKey == "" {
@@ -667,7 +717,18 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Error: Workspace ID is required. Use -wksp flag or set JSMON_WORKSPACE_ID environment variable\n")
 			os.Exit(1)
 		}
-		handlers.HandleDomainScan(*domainFlag, workspaceID, apiKey, "", headers)
+		handlers.HandleDomainScan(*domainFlag, workspaceID, apiKey, "", headers, scanDepth)
+	} else if codeScanPath != "" {
+		// Source code scan
+		if apiKey == "" {
+			fmt.Fprintf(os.Stderr, "Error: API key is required. Use -key flag, add to ~/.jsmon/credentials, or set JSMON_API_KEY environment variable\n")
+			os.Exit(1)
+		}
+		if workspaceID == "" {
+			fmt.Fprintf(os.Stderr, "Error: Workspace ID is required. Use -wksp flag or set JSMON_WORKSPACE_ID environment variable\n")
+			os.Exit(1)
+		}
+		handlers.HandleCodeScan(codeScanPath, workspaceID, apiKey, headers)
 	} else if *fileFlag != "" {
 		// File upload
 		if apiKey == "" {
@@ -706,12 +767,14 @@ func showUsage() {
 	fmt.Fprintf(os.Stderr, "Input:\n")
 	fmt.Fprintf(os.Stderr, "  -u <input>                                  Input URL to scan\n")
 	fmt.Fprintf(os.Stderr, "  -d <input>                                  Input domain to scan\n")
+	fmt.Fprintf(os.Stderr, "  -cs <input> | -code-scan <input>            Input source code file to scan\n")
 	fmt.Fprintf(os.Stderr, "  -f <input>                                  Input file of URLs to scan (one URL per line)\n")
 	fmt.Fprintf(os.Stderr, "  -cw <input> | --create-workspace <input>    Create a new workspace\n\n")
 
 	fmt.Fprintf(os.Stderr, "Configuration:\n")
 	fmt.Fprintf(os.Stderr, "  -key <input>                                API key (or add the API key to ~/.jsmon/credentials)\n")
 	fmt.Fprintf(os.Stderr, "  -wksp <wksp id>                             Workspace ID to scan the target\n")
+	fmt.Fprintf(os.Stderr, "  -depth <1..4> | -scan-depth <1..4>          Optional scan depth for domain scans\n")
 	fmt.Fprintf(os.Stderr, "  -H <input>                                  Custom HTTP headers to send along with request to scan\n")
 	fmt.Fprintf(os.Stderr, "  -resume                                     Resume scan using resume.config\n")
 	fmt.Fprintf(os.Stderr, "                                              (resumes from last scan failed due to force stop or API limits)\n")
@@ -727,6 +790,9 @@ func showUsage() {
 
 	fmt.Fprintf(os.Stderr, "Data:\n")
 	fmt.Fprintf(os.Stderr, "  -workspaces                                 Fetch all workspaces\n")
+	fmt.Fprintf(os.Stderr, "  -issues \"page=<n> limit=<n> ...\"            Fetch dashboard vulnerabilities for a workspace (default: page=1, limit=100)\n")
+	fmt.Fprintf(os.Stderr, "                                              Supported options: severity, dateFrom, dateTo\n")
+	fmt.Fprintf(os.Stderr, "                                              Example: -issues \"page=1 limit=20 severity=critical,high dateFrom=2026-04-01 dateTo=2026-04-14\"\n")
 	fmt.Fprintf(os.Stderr, "  -secrets \"page=<number> limit=<number>\"      Fetch all secrets for a workspace (default: page=1, limit=100)\n")
 	fmt.Fprintf(os.Stderr, "  -recon \"field=<name> page=<number> limit=<number>\"\n")
 	fmt.Fprintf(os.Stderr, "                                              Fetch the reconnaissance data (default: page=1, limit=100)\n")
@@ -784,4 +850,78 @@ func parseHeadersAndFilterArgs() (map[string]string, []string) {
 	}
 
 	return headers, filteredArgs
+}
+
+func looksLikeKeyValueArg(arg string) bool {
+	return arg != "" && !strings.HasPrefix(arg, "-") && strings.Contains(arg, "=")
+}
+
+func parseCSVValues(value string) []string {
+	parts := strings.Split(value, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			values = append(values, part)
+		}
+	}
+	return values
+}
+
+func parsePositiveInt(value, fieldName string) (int, error) {
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return 0, fmt.Errorf("invalid %s value %q", fieldName, value)
+	}
+	return parsed, nil
+}
+
+func parseIssuesOptions(raw string) (api.IssuesQueryOptions, error) {
+	options := api.IssuesQueryOptions{
+		Page:  1,
+		Limit: 100,
+	}
+
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return options, nil
+	}
+
+	for _, part := range strings.Fields(raw) {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return options, fmt.Errorf("invalid issues option %q. Use key=value pairs", part)
+		}
+
+		key := strings.ToLower(strings.TrimSpace(kv[0]))
+		value := strings.TrimSpace(kv[1])
+		if value == "" {
+			return options, fmt.Errorf("missing value for issues option %q", key)
+		}
+
+		switch key {
+		case "page":
+			page, err := parsePositiveInt(value, "page")
+			if err != nil {
+				return options, err
+			}
+			options.Page = page
+		case "limit":
+			limit, err := parsePositiveInt(value, "limit")
+			if err != nil {
+				return options, err
+			}
+			options.Limit = limit
+		case "severity":
+			options.Severity = parseCSVValues(value)
+		case "datefrom":
+			options.DateFrom = value
+		case "dateto":
+			options.DateTo = value
+		default:
+			return options, fmt.Errorf("unsupported issues option %q", key)
+		}
+	}
+
+	return options, nil
 }


### PR DESCRIPTION
## Summary
- add `-depth` / `-scan-depth` support for domain scans and pass `scanDepth` through the API client
- add `-cs` / `-code-scan` support for direct source code uploads via `/directFileScan`
- add `-issues` support for the mounted dashboard vulnerability table via `/vulnerability`, and update help and README coverage
- fix `createWorkspace` response parsing to support the current `workspace.wkspId` shape while remaining compatible with the older top-level `workspaceId` field

## Test plan
- [x] `go build ./...`
- [x] `go install .`
- [x] `go run . -d \"example.com\" -depth 2 -wksp 0053e73a-86fa-48ad-9032-b638331adb4c -silent -duc`
- [x] `go run . -cs \"/Users/siddhartha/Documents/code/jsmon-cli/main.go\" -wksp 0053e73a-86fa-48ad-9032-b638331adb4c -silent -duc`
- [x] `go run . -issues \"page=1 limit=5\" -wksp 0053e73a-86fa-48ad-9032-b638331adb4c -silent -duc`
- [x] `go run . -issues \"page=1 limit=5 severity=critical,high\" -wksp 0053e73a-86fa-48ad-9032-b638331adb4c -silent -duc`
- [x] `go run . -issues \"page=1 limit=3 dateFrom=2026-04-14 dateTo=2026-04-14\" -wksp 0053e73a-86fa-48ad-9032-b638331adb4c -silent -duc`
- [x] `go run . -cw \"parser-fix repo 20260414-161300\" -silent -duc`
- [x] `/Users/siddhartha/go/bin/jsmon-cli -cw \"parser-fix install 20260414-161300\" -silent -duc`
- [x] `/Users/siddhartha/go/bin/jsmon-cli` retested for the touched flows after local reinstall