### PR TITLE
JSV-913: align CLI with expired domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Help:
 Field Names:
   -recon, -rsearch:
     apiPaths, urls, extractedDomains, ip, emails, s3Buckets, s3takeovers,gqlQueries, gqlMutaions, gqlFragments, param (extracted parameter),
-    npmPackages, npmConfusion, guids, localhost, activeDomains,inactiveDomains, allAwsAssets, queryparams, socialUrls,
+    npmPackages, npmConfusion, guids, localhost, expiredDomains, allAwsAssets, queryparams, socialUrls,
     portUrls, extensionUrls
 
   -filters:
@@ -233,7 +233,7 @@ Get extracted intelligence for a **field** and optional pagination:
 jsmon -recon "field=emails page=1 limit=50" -wksp YOUR_WORKSPACE_ID
 ```
 
-**Common fields:** `apiPaths`, `urls`, `extractedDomains`, `ip`, `emails`, `s3Buckets`, `gqlQueries`, `gqlFragments`, `param`, `queryparams`, `allAwsAssets`, `npmPackages`, `socialUrls`, `portUrls`, `extensionUrls`, and others (see `jsmon -h`).
+**Common fields:** `apiPaths`, `urls`, `extractedDomains`, `expiredDomains`, `ip`, `emails`, `s3Buckets`, `gqlQueries`, `gqlFragments`, `param`, `queryparams`, `allAwsAssets`, `npmPackages`, `socialUrls`, `portUrls`, `extensionUrls`, and others (see `jsmon -h`).
 
 ### Filter by keyword (`-filters`)
 

--- a/api/client.go
+++ b/api/client.go
@@ -441,7 +441,7 @@ type TotalCountAnalysis struct {
 	TotalValidNodeModules               int `json:"totalValidNodeModules"`
 	TotalQueryParamsUrls                int `json:"totalQueryParamsUrls"`
 	TotalS3DomainsInvalid               int `json:"totalS3DomainsInvalid"`
-	TotalExtractedDomainsStatus         int `json:"totalExtractedDomainsStatus"`
+	TotalExpiredDomains                 int `json:"totalExpiredDomains"`
 	TotalSocialMediaUrls                int `json:"totalSocialMediaUrls"`
 	TotalLocalhostUrls                  int `json:"totalLocalhostUrls"`
 	TotalFilteredPortUrls               int `json:"totalFilteredPortUrls"`
@@ -1030,8 +1030,7 @@ func mapFieldToOptions(field string) string {
 		"npmconfusion":     "invalidnodemodules",
 		"guids":            "guids",
 		"localhost":        "localhost",
-		"activedomains":    "domainsstatus",
-		"inactivedomains":  "domainsstatus",
+		"expireddomains":   "expireddomains",
 		"allawsassets":     "awsassets",
 		"queryparam":       "queryparams",
 		"socialurls":       "socialmediaurls",
@@ -1049,13 +1048,6 @@ func mapFieldToOptions(field string) string {
 
 // getStatusForField returns the status parameter value for fields that require it
 func getStatusForField(field string) string {
-	fieldLower := strings.ToLower(field)
-	if fieldLower == "activedomains" {
-		return "active"
-	}
-	if fieldLower == "inactivedomains" {
-		return "inactive"
-	}
 	return ""
 }
 

--- a/handlers/count.go
+++ b/handlers/count.go
@@ -121,7 +121,7 @@ func HandleCount(workspaceID, apiKey string, headers map[string]string, runID st
 	// 🔗 URLs & Links (sorted by count)
 	fmt.Printf("\n%s🔗 URLs & Links%s\n", ColorGreen, ColorReset)
 	displaySortedCounts([]countItem{
-		{"Total Extracted Domains Status", countAnalysis.TotalExtractedDomainsStatus},
+		{"Total Expired Domains", countAnalysis.TotalExpiredDomains},
 		{"Total File Extension URLs", countAnalysis.TotalFileExtensionUrls},
 		{"Total Filtered Port URLs", countAnalysis.TotalFilteredPortUrls},
 		{"Total Localhost URLs", countAnalysis.TotalLocalhostUrls},

--- a/handlers/reconnaissance.go
+++ b/handlers/reconnaissance.go
@@ -15,13 +15,6 @@ type ParamValue struct {
 	Parameters []map[string]interface{} `json:"parameters"`
 }
 
-// DomainStatusValue represents a domain status value with domainName, status, and expiryDate
-type DomainStatusValue struct {
-	DomainName string `json:"domainName"`
-	Status     string `json:"status"`
-	ExpiryDate string `json:"expiryDate"`
-}
-
 // HandleJSIntelligence displays reconnaissance data for a workspace in raw JSON format
 func HandleJSIntelligence(workspaceID, apiKey string, headers map[string]string, field string, page int, limit int) {
 	client := api.NewClient(apiKey, headers)
@@ -47,7 +40,6 @@ func HandleJSIntelligence(workspaceID, apiKey string, headers map[string]string,
 
 	// Check if this is a field with object values (not strings)
 	isParamField := strings.ToLower(field) == "param"
-	isDomainStatusField := strings.ToLower(field) == "activedomains" || strings.ToLower(field) == "inactivedomains"
 	isAwsAssetsField := strings.ToLower(field) == "awsassets" || strings.ToLower(field) == "allawsassets"
 
 	var output interface{}
@@ -82,40 +74,6 @@ func HandleJSIntelligence(workspaceID, apiKey string, headers map[string]string,
 			}
 		}
 		output = paramValues
-	} else if isDomainStatusField {
-		// For domain status fields, extract the full value objects
-		var domainValues []DomainStatusValue
-		if data, ok := response["data"].([]interface{}); ok {
-			for _, item := range data {
-				if itemMap, ok := item.(map[string]interface{}); ok {
-					if value, exists := itemMap["value"]; exists && value != nil {
-						if valueMap, ok := value.(map[string]interface{}); ok {
-							domainValue := DomainStatusValue{}
-							if domainName, exists := valueMap["domainName"]; exists {
-								if domainNameStr, ok := domainName.(string); ok {
-									domainValue.DomainName = domainNameStr
-								}
-							}
-							if status, exists := valueMap["status"]; exists {
-								if statusStr, ok := status.(string); ok {
-									domainValue.Status = statusStr
-								}
-							}
-							if expiryDate, exists := valueMap["expiryDate"]; exists {
-								// expiryDate can be a string or null, handle both
-								if expiryDateStr, ok := expiryDate.(string); ok {
-									domainValue.ExpiryDate = expiryDateStr
-								} else if expiryDate == nil {
-									domainValue.ExpiryDate = "NULL"
-								}
-							}
-							domainValues = append(domainValues, domainValue)
-						}
-					}
-				}
-			}
-		}
-		output = domainValues
 	} else if isAwsAssetsField {
 		// For awsassets field, extract the full value objects (AWS assets are objects)
 		var awsAssets []map[string]interface{}

--- a/main.go
+++ b/main.go
@@ -748,7 +748,7 @@ func showUsage() {
 	fmt.Fprintf(os.Stderr, "Field Names:\n")
 	fmt.Fprintf(os.Stderr, "  -recon, -rsearch:\n")
 	fmt.Fprintf(os.Stderr, "    apiPaths, urls, extractedDomains, ip, emails, s3Buckets, s3takeovers,gqlQueries, gqlMutaions, gqlFragments, param (extracted parameter),\n")
-	fmt.Fprintf(os.Stderr, "    npmPackages, npmConfusion, guids, localhost, activeDomains,inactiveDomains, allAwsAssets, queryparams, socialUrls,\n")
+	fmt.Fprintf(os.Stderr, "    npmPackages, npmConfusion, guids, localhost, expiredDomains, allAwsAssets, queryparams, socialUrls,\n")
 	fmt.Fprintf(os.Stderr, "    portUrls, extensionUrls\n\n")
 	fmt.Fprintf(os.Stderr, "  -filters:\n")
 	fmt.Fprintf(os.Stderr, "    jsurls, apiPaths, urls, emails, gqlQueries, gqlMutaions,sqlFragments, param (extracted parameter)\n")


### PR DESCRIPTION
## Summary
- replace the CLI active/inactive domain status flow with `expireddomains`
- align count output with `totalExpiredDomains`
- simplify reconnaissance raw output for expired domains to string values

## Test plan
- [x] `go test ./...`