### PR TITLE
Fix Go v2 module install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ jsmon -recon "field=emails page=1" -wksp YOUR_WORKSPACE_ID
 ### Option 1: Install from Go (recommended)
 
 ```bash
-go install github.com/jsmonhq/jsmon-cli@latest
+go install github.com/jsmonhq/jsmon-cli/v2@latest
 ```
+
+For v2 and newer releases, include `/v2` in the module path. The old
+`github.com/jsmonhq/jsmon-cli@latest` path resolves only the v1 release line.
 
 Ensure your Go `bin` directory is in your `PATH` (e.g. `$HOME/go/bin`). The binary is typically named `jsmon-cli`; you can rename or symlink it to `jsmon` if you prefer.
 
@@ -302,7 +305,7 @@ Format: `"fieldname=value"`. Use **extractedDomains** (not `domains`) for domain
 To upgrade after a new release:
 
 ```bash
-go install github.com/jsmonhq/jsmon-cli@latest
+go install github.com/jsmonhq/jsmon-cli/v2@latest
 ```
 
 ---

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -8,7 +8,7 @@ Add screenshots here so the main README displays them. Use the filenames below s
 |----------|------------------|--------------------|
 | `help.png` | CLI help output (logo + usage) | `jsmon -h` or `jsmon -help` |
 | `quickstart.png` | Create workspace + one scan | `jsmon -cw "Test" -key KEY` then `jsmon -u "https://example.com/a.js" -wksp ID` |
-| `install.png` | Successful install (terminal) | `go install github.com/jsmonhq/jsmon-cli@latest` and `jsmon -h` |
+| `install.png` | Successful install (terminal) | `go install github.com/jsmonhq/jsmon-cli/v2@latest` and `jsmon -h` |
 | `config.png` | Config in use (e.g. listing workspaces) | `jsmon -workspaces -key YOUR_KEY` |
 | `scanning.png` | URL or domain scan in progress / result | `jsmon -u "https://example.com/app.js" -wksp ID` |
 | `recon.png` | Recon or filter output (JSON) | `jsmon -recon "field=emails page=1" -wksp ID` or `jsmon -filters "urls=github page=1" -wksp ID` |

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/jsmonhq/jsmon-cli
+module github.com/jsmonhq/jsmon-cli/v2
 
 go 1.21

--- a/handlers/code.go
+++ b/handlers/code.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleCodeScan uploads a source code file for code scanning.

--- a/handlers/colors.go
+++ b/handlers/colors.go
@@ -5,4 +5,3 @@ const (
 	ColorGreen = "\033[32m"
 	ColorReset = "\033[0m"
 )
-

--- a/handlers/count.go
+++ b/handlers/count.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // countItem represents a label-value pair for sorting

--- a/handlers/domain.go
+++ b/handlers/domain.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleDomainScan scans a domain. The exact value passed via -d is sent to the API.

--- a/handlers/domains.go
+++ b/handlers/domains.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleDomains displays domain scans for a workspace in JSON format

--- a/handlers/file.go
+++ b/handlers/file.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // FileScanResult represents the result of a file scan

--- a/handlers/filescans.go
+++ b/handlers/filescans.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleFileScans displays file scans for a workspace in JSON format
@@ -40,4 +40,3 @@ func HandleFileScans(workspaceID, apiKey string, headers map[string]string, page
 
 	fmt.Println(string(jsonOutput))
 }
-

--- a/handlers/filter.go
+++ b/handlers/filter.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleFilter displays filtered reconnaissance data for a workspace

--- a/handlers/issues.go
+++ b/handlers/issues.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleIssues fetches workspace issues and prints them in JSON format.

--- a/handlers/jsurls.go
+++ b/handlers/jsurls.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleJSURLs displays JS URLs for a workspace in JSON format

--- a/handlers/reconnaissance.go
+++ b/handlers/reconnaissance.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // ParamValue represents a parameter value with url and parameters

--- a/handlers/reversesearch.go
+++ b/handlers/reversesearch.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // URLItem represents a URL item with url before createdAt

--- a/handlers/scan_submit.go
+++ b/handlers/scan_submit.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 func printScanQueued(label, target string, response *api.ScanSubmitResponse) {

--- a/handlers/secrets.go
+++ b/handlers/secrets.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // SecretOutput represents the output format for secrets (without source and occurrences, with reordered fields)

--- a/handlers/url.go
+++ b/handlers/url.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleURLUpload uploads a URL for scanning

--- a/handlers/workspace.go
+++ b/handlers/workspace.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleCreateWorkspace creates a new workspace

--- a/handlers/workspaces.go
+++ b/handlers/workspaces.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jsmonhq/jsmon-cli/api"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
 )
 
 // HandleWorkspaces displays all workspaces for the user

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jsmonhq/jsmon-cli/api"
-	"github.com/jsmonhq/jsmon-cli/config"
-	"github.com/jsmonhq/jsmon-cli/handlers"
+	"github.com/jsmonhq/jsmon-cli/v2/api"
+	"github.com/jsmonhq/jsmon-cli/v2/config"
+	"github.com/jsmonhq/jsmon-cli/v2/handlers"
 )
 
 var allowedScanExtensions = map[string]bool{

--- a/update.go
+++ b/update.go
@@ -15,9 +15,11 @@ import (
 
 const (
 	// Version is the current version of the CLI (must match the latest release tag)
-	Version = "2.1.0"
+	Version = "2.1.1"
 	// GitHubRepo is the repository for checking updates
 	GitHubRepo = "jsmonhq/jsmon-cli"
+	// InstallModule is the Go module path users install from.
+	InstallModule = "github.com/jsmonhq/jsmon-cli/v2"
 )
 
 // GitHubRelease represents a GitHub release
@@ -69,6 +71,7 @@ func checkForUpdate() {
 	// Simple version comparison (works for semantic versioning)
 	if compareVersions(latestVersion, currentVersion) > 0 {
 		fmt.Fprintf(os.Stderr, "\n[INF] A new version is available: %s (current: %s)\n", latestVersion, currentVersion)
+		fmt.Fprintf(os.Stderr, "[INF] Update with: go install %s@latest\n\n", InstallModule)
 	}
 }
 
@@ -120,7 +123,7 @@ func checkAndUpdateCLI() {
 		os.Exit(0)
 	}
 
-	cmd := exec.Command("go", "install", "github.com/jsmonhq/jsmon-cli@latest")
+	cmd := exec.Command("go", "install", InstallModule+"@latest")
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Summary
- Align the CLI module path and imports with Go v2 module semantics.
- Update install and updater instructions to use the v2 module path.

## Test plan
- `go test ./...`