### PR TITLE
Install CLI as jsmon and removed deprecated params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-jsmon*
+/jsmon*
 .vscode
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -47,23 +47,20 @@ jsmon -recon "field=emails page=1" -wksp YOUR_WORKSPACE_ID
 ### Option 1: Install from Go (recommended)
 
 ```bash
-go install github.com/jsmonhq/jsmon-cli/v2@latest
+go install github.com/jsmonhq/jsmon-cli/v2/cmd/jsmon@latest
 ```
 
-For v2 and newer releases, include `/v2` in the module path. The old
-`github.com/jsmonhq/jsmon-cli@latest` path resolves only the v1 release line.
-
-Ensure your Go `bin` directory is in your `PATH` (e.g. `$HOME/go/bin`). The binary is typically named `jsmon-cli`; you can rename or symlink it to `jsmon` if you prefer.
+Ensure your Go `bin` directory is in your `PATH` (e.g. `$HOME/go/bin`). The installed command is `jsmon`.
 
 ### Option 2: Build from source
 
 ```bash
 git clone https://github.com/jsmonhq/jsmon-cli.git
 cd jsmon-cli
-go build -o jsmon .
+go build -o jsmon ./cmd/jsmon
 ```
 
-Use `-o jsmon` to get a binary named `jsmon`.
+This creates a local `jsmon` binary from source.
 
 ---
 
@@ -71,7 +68,7 @@ Use `-o jsmon` to get a binary named `jsmon`.
 
 ### API key
 
-Get your API key from [JSMon](https://jsmon.sh). The CLI looks for it in this order:
+Get your API key from [JSMon](https://app.jsmon.sh/settings). The CLI looks for it in this order:
 
 | Priority | Source |
 |----------|--------|
@@ -108,7 +105,7 @@ Scan commands submit work to JSMon's asynchronous pipeline. The CLI prints the q
 ## Commands Overview
 
 ```
-Usage: jsmon-cli [OPTIONS]
+Usage: jsmon [OPTIONS]
 
 Input:
   -u <input>                                  Input URL to scan
@@ -136,6 +133,16 @@ Scans:
   --domains "page=<page number> limit=<number>" Fetch all scanned domains (default: page=1, limit=100)
   --files "page=<page number> limit=<number>"  Fetch all scanned files (default: page=1, limit=100)
 
+Advanced Scan:
+  Supported scan types:
+    -wafbypass                               URL, domain, and file scans
+    -depth, -keywords, -extensions           Domain scans only
+  Allowed extensions: html, php, txt, js, xml, json, map, xhtml, aspx
+  Examples:
+    jsmon -u "https://example.com/app.js" -wafbypass -wksp <wksp id>
+    jsmon -d "example.com" -depth 3 -keywords "api,admin" -extensions "js,json" -wafbypass -wksp <wksp id>
+    jsmon -f urls.txt -wafbypass -wksp <wksp id>
+
 Data:
   -workspaces                                 Fetch all workspaces
   -issues "page=<n> limit=<n> ..."            Fetch dashboard vulnerabilities for a workspace (default: page=1, limit=100)
@@ -162,7 +169,7 @@ Help:
 Field Names:
   -recon, -rsearch:
     apiPaths, urls/jsurls (scanned URLs), extractedUrls, extractedDomains, ip, emails, s3Buckets, s3takeovers, gqlQueries, gqlMutations, gqlMutaions, gqlFragments, param (extracted parameter),
-    npmPackages, npmConfusion, guids, localhost, expiredDomains, allAwsAssets, queryparams, socialUrls,
+    npmPackages, npmConfusion, guids, localhost, expiredDomains, allAwsAssets, socialUrls,
     portUrls, extensionUrls
 
   -filters:
@@ -264,7 +271,7 @@ Get extracted intelligence for a **field** and optional pagination:
 jsmon -recon "field=emails page=1 limit=50" -wksp YOUR_WORKSPACE_ID
 ```
 
-**Common fields:** `apiPaths`, `urls`/`jsurls` for scanned URLs, `extractedUrls` for automation-extracted URL strings, `extractedDomains`, `expiredDomains`, `ip`, `emails`, `s3Buckets` (`awsassets.s3buckets`), `gqlQueries`, `gqlMutations`, `gqlFragments`, `param`, `queryparams`, `allAwsAssets`, `npmPackages`, `socialUrls`, `portUrls`, `extensionUrls`, and others (see `jsmon -h`).
+**Common fields:** `apiPaths`, `urls`/`jsurls` for scanned URLs, `extractedUrls` for automation-extracted URL strings, `extractedDomains`, `expiredDomains`, `ip`, `emails`, `s3Buckets` (`awsassets.s3buckets`), `gqlQueries`, `gqlMutations`, `gqlFragments`, `param`, `allAwsAssets`, `npmPackages`, `socialUrls`, `portUrls`, `extensionUrls`, and others (see `jsmon -h`).
 
 Add `runId=<id>` to scope results to one scan. Add `version=<n>` with `runId` to inspect a specific monitoring/rescan version.
 
@@ -305,7 +312,7 @@ Format: `"fieldname=value"`. Use **extractedDomains** (not `domains`) for domain
 To upgrade after a new release:
 
 ```bash
-go install github.com/jsmonhq/jsmon-cli/v2@latest
+go install github.com/jsmonhq/jsmon-cli/v2/cmd/jsmon@latest
 ```
 
 ---

--- a/api/client.go
+++ b/api/client.go
@@ -1245,8 +1245,6 @@ func mapFieldToOptions(field string) string {
 		"expireddomains":   "expireddomains",
 		"awsassets":        "awsassets",
 		"allawsassets":     "awsassets",
-		"queryparam":       "queryparams",
-		"queryparams":      "queryparams",
 		"socialurls":       "socialmediaurls",
 		"porturls":         "filteredporturls",
 		"extensionurls":    "fileextensionurls",

--- a/cmd/jsmon/main.go
+++ b/cmd/jsmon/main.go
@@ -1,0 +1,7 @@
+package main
+
+import jsmoncli "github.com/jsmonhq/jsmon-cli/v2"
+
+func main() {
+	jsmoncli.Main()
+}

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -8,7 +8,7 @@ Add screenshots here so the main README displays them. Use the filenames below s
 |----------|------------------|--------------------|
 | `help.png` | CLI help output (logo + usage) | `jsmon -h` or `jsmon -help` |
 | `quickstart.png` | Create workspace + one scan | `jsmon -cw "Test" -key KEY` then `jsmon -u "https://example.com/a.js" -wksp ID` |
-| `install.png` | Successful install (terminal) | `go install github.com/jsmonhq/jsmon-cli/v2@latest` and `jsmon -h` |
+| `install.png` | Successful install (terminal) | `go install github.com/jsmonhq/jsmon-cli/v2/cmd/jsmon@latest` and `jsmon -h` |
 | `config.png` | Config in use (e.g. listing workspaces) | `jsmon -workspaces -key YOUR_KEY` |
 | `scanning.png` | URL or domain scan in progress / result | `jsmon -u "https://example.com/app.js" -wksp ID` |
 | `recon.png` | Recon or filter output (JSON) | `jsmon -recon "field=emails page=1" -wksp ID` or `jsmon -filters "urls=github page=1" -wksp ID` |

--- a/logo.go
+++ b/logo.go
@@ -1,4 +1,4 @@
-package main
+package jsmoncli
 
 const LogoColor = `
 ` + "\033[36m" + `     ██╗███████╗███╗   ███╗ ██████╗ ███╗   ██╗` + "\033[0m" + `

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main
+package jsmoncli
 
 import (
 	"flag"
@@ -24,7 +24,7 @@ var allowedScanExtensions = map[string]bool{
 	"aspx":  true,
 }
 
-func main() {
+func Main() {
 	// Store original args
 	originalArgs := make([]string, len(os.Args))
 	copy(originalArgs, os.Args)
@@ -851,7 +851,7 @@ func showUsage() {
 		fmt.Fprint(os.Stderr, LogoColor)
 	}
 
-	fmt.Fprintf(os.Stderr, "\nUsage: jsmon-cli [OPTIONS]\n\n")
+	fmt.Fprintf(os.Stderr, "\nUsage: jsmon [OPTIONS]\n\n")
 
 	fmt.Fprintf(os.Stderr, "Input:\n")
 	fmt.Fprintf(os.Stderr, "  -u <input>                                  Input URL to scan\n")
@@ -916,7 +916,7 @@ func showUsage() {
 	fmt.Fprintf(os.Stderr, "Field Names:\n")
 	fmt.Fprintf(os.Stderr, "  -recon, -rsearch:\n")
 	fmt.Fprintf(os.Stderr, "    apiPaths, urls/jsurls (scanned URLs), extractedUrls, extractedDomains, ip, emails, s3Buckets, s3takeovers, gqlQueries, gqlMutations, gqlMutaions, gqlFragments, param (extracted parameter),\n")
-	fmt.Fprintf(os.Stderr, "    npmPackages, npmConfusion, guids, localhost, expiredDomains, allAwsAssets, queryparams, socialUrls,\n")
+	fmt.Fprintf(os.Stderr, "    npmPackages, npmConfusion, guids, localhost, expiredDomains, allAwsAssets, socialUrls,\n")
 	fmt.Fprintf(os.Stderr, "    portUrls, extensionUrls\n\n")
 	fmt.Fprintf(os.Stderr, "  -filters:\n")
 	fmt.Fprintf(os.Stderr, "    jsurls, apiPaths, urls, emails, gqlQueries, gqlMutations, gqlMutaions, sqlFragments, param (extracted parameter)\n")

--- a/update.go
+++ b/update.go
@@ -1,4 +1,4 @@
-package main
+package jsmoncli
 
 import (
 	"encoding/json"
@@ -18,8 +18,8 @@ const (
 	Version = "2.1.1"
 	// GitHubRepo is the repository for checking updates
 	GitHubRepo = "jsmonhq/jsmon-cli"
-	// InstallModule is the Go module path users install from.
-	InstallModule = "github.com/jsmonhq/jsmon-cli/v2"
+	// InstallModule is the Go command package path users install from.
+	InstallModule = "github.com/jsmonhq/jsmon-cli/v2/cmd/jsmon"
 )
 
 // GitHubRelease represents a GitHub release


### PR DESCRIPTION
Add a dedicated jsmon command entrypoint so users can install and run the CLI with the expected jsmon binary name while keeping the repository and module under jsmon-cli.

Update install, build, update, and help documentation to use the new command path, and remove the deprecated queryparams field from the public field list and API mapping.