### PR TITLE
Bump version to 2.1.3

### DIFF
--- a/update.go
+++ b/update.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// Version is the current version of the CLI (must match the latest release tag)
-	Version = "2.1.2"
+	Version = "2.1.3"
 	// GitHubRepo is the repository for checking updates
 	GitHubRepo = "jsmonhq/jsmon-cli"
 	// InstallModule is the Go command package path users install from.


### PR DESCRIPTION
## Summary
- Bumps the `Version` constant to `2.1.3`
- The `v2.1.2` GitHub release tag was cut from a commit where `Version` was still hardcoded to `"2.1.1"`, so installed binaries reported themselves as out of date in a loop
- This release will be tagged/published from a commit where `Version` actually matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)